### PR TITLE
Composer: avoid writing a lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
     "bin": ["var-dump-check"],
     "replace": {
         "jakub-onderka/php-var-dump-check": "*"
+    },
+    "config": {
+        "lock": false
     }
 }


### PR DESCRIPTION
When working with this repository as a developer, we should be using the latest compatible packages. By writing a lock file for Composer, we may get into a state where we are "stuck" on an older version of a dependency. This change avoids such a situation by telling Composer to not write out a lock file in the project.